### PR TITLE
LCD-44380 OCI PoC

### DIFF
--- a/templates/minio/statefulset.yaml
+++ b/templates/minio/statefulset.yaml
@@ -98,19 +98,17 @@ spec:
           failureThreshold: 3
         volumeMounts:
         - mountPath: /tmp
-          name: empty-dir
+          name: liferay-minio-pvc
           subPath: tmp-dir
         - mountPath: /opt/bitnami/minio/tmp
-          name: empty-dir
+          name: liferay-minio-pvc
           subPath: app-tmp-dir
         - mountPath: /.mc
-          name: empty-dir
+          name: liferay-minio-pvc
           subPath: app-mc-dir
         - mountPath: /bitnami/minio/data
           name: liferay-minio-pvc
-      volumes:
-      - emptyDir: {}
-        name: empty-dir
+          subPath: data-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/templates/minio/statefulset.yaml
+++ b/templates/minio/statefulset.yaml
@@ -20,8 +20,24 @@ spec:
         app: {{ $.Chart.Name }}-minio
         {{- include "liferay.labels" $ | nindent 8 }}
     spec:
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: {{ $.Chart.Name }}-minio
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
         env:
           - name: MINIO_API_PORT_NUMBER
             value: {{ default "9000" .config.ports.api | quote }}
@@ -81,8 +97,20 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         volumeMounts:
+        - mountPath: /tmp
+          name: empty-dir
+          subPath: tmp-dir
+        - mountPath: /opt/bitnami/minio/tmp
+          name: empty-dir
+          subPath: app-tmp-dir
+        - mountPath: /.mc
+          name: empty-dir
+          subPath: app-mc-dir
         - mountPath: /bitnami/minio/data
           name: liferay-minio-pvc
+      volumes:
+      - emptyDir: {}
+        name: empty-dir
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/templates/postgres/statefulset.yaml
+++ b/templates/postgres/statefulset.yaml
@@ -31,6 +31,8 @@ spec:
             value: {{ .config.user }}
           - name: PGUSER
             value: {{ .config.user }}
+          - name: PGDATA
+            value: /var/lib/postgresql/data/db
           {{- with .internal.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
- **LCD-44380 avoids problem when data folder is on new ext4 volume which has "lost+found" already existing**
- **LCD-44380 copy the securityContext blocks from binami/minio official chart**
